### PR TITLE
docs: 接入官方 Claude Code 技能市场 claude_marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,16 @@ Explore our [example library](https://langgptai.feishu.cn/wiki/RXdbwRyASiShtDky3
 
 If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), install the LangGPT Skill to get structured prompt writing capabilities:
 
-**Installation:**
+**Install via the official marketplace (recommended):**
+
+```bash
+/plugin marketplace add langgptai/claude_marketplace
+/plugin install structured-prompt-writer@langgpt
+```
+
+The [LangGPT marketplace](https://github.com/langgptai/claude_marketplace) also ships more battle-tested skills by Yunzhong Jiangshu — `awesome-design-html` (115 brand-themed design references), `cto`, and `mind-clone`.
+
+**Or install manually:**
 
 1. Download [langgpt.skill](https://github.com/langgptai/LangGPT/releases)
 2. Extract to `~/.claude/skills/` directory
@@ -242,6 +251,7 @@ skills:
 | **[PromptVer](https://github.com/langgptai/PromptVer)** | Semantic versioning for prompts — version control like Git | ![](https://badgen.net/github/stars/langgptai/PromptVer) |
 | **[PromptShow](https://github.com/langgptai/PromptShow)** | Create beautiful prompt images ([Try it](https://show.langgpt.ai/)) | ![](https://badgen.net/github/stars/langgptai/PromptShow) |
 | **[Minstrel](https://github.com/langgptai/Minstrel)** | Multi-agent system for auto-generating prompts | ![](https://badgen.net/github/stars/langgptai/Minstrel) |
+| **[claude_marketplace](https://github.com/langgptai/claude_marketplace)** | Official Claude Code skill marketplace — structured prompt, design, CTO, mind-clone | ![](https://badgen.net/github/stars/langgptai/claude_marketplace) |
 
 ### Model-Specific Prompt Collections
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -80,6 +80,31 @@ AIにプロンプトを作成させる：
 
 [サンプルライブラリ](https://langgptai.feishu.cn/wiki/RXdbwRyASiShtDky381ciwFEnpe)を探索し、実証済みのテンプレートをニーズに合わせて調整してください。
 
+### 方法4: Claude Code Skill（推奨）
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) を使用している場合、LangGPT Skill をインストールすると、構造化プロンプトの作成機能を利用できます。
+
+**公式マーケットプレイス経由でインストール（推奨）：**
+
+```bash
+/plugin marketplace add langgptai/claude_marketplace
+/plugin install structured-prompt-writer@langgpt
+```
+
+[LangGPT マーケットプレイス](https://github.com/langgptai/claude_marketplace) には、雲中江樹が磨き上げた実戦的なスキルも収録されています — `awesome-design-html`（115 種のブランドテーマ別デザインリファレンス）、`cto`、`mind-clone`。
+
+**または手動でインストール：**
+
+1. [langgpt.skill](https://github.com/langgptai/LangGPT/releases) をダウンロード
+2. `~/.claude/skills/` ディレクトリに展開
+3. Claude Code で `/langgpt` と入力して使用
+
+**Skill の機能：**
+- 📝 構造化プロンプトテンプレート（Role、Profile、Skills、Rules、Workflow）
+- 📚 豊富なサンプルライブラリ（フィットネス計画、詩作、小紅書ライター、命名マスターなど）
+- 🔧 変数、コマンド、条件ロジックなどの高度なテクニック
+- 🎯 モデル互換性ガイド（GPT-4、Claude、GPT-3.5）
+
 ---
 
 ## 🧠 理論的基礎
@@ -221,6 +246,7 @@ skills:
 | **[PromptVer](https://github.com/langgptai/PromptVer)** | プロンプトのセマンティックバージョニング — Gitのようなバージョン管理 | ![](https://badgen.net/github/stars/langgptai/PromptVer) |
 | **[PromptShow](https://github.com/langgptai/PromptShow)** | 美しいプロンプト画像を作成（[試す](https://show.langgpt.ai/)） | ![](https://badgen.net/github/stars/langgptai/PromptShow) |
 | **[Minstrel](https://github.com/langgptai/Minstrel)** | プロンプト自動生成のためのマルチエージェントシステム | ![](https://badgen.net/github/stars/langgptai/Minstrel) |
+| **[claude_marketplace](https://github.com/langgptai/claude_marketplace)** | 公式 Claude Code スキルマーケットプレイス — 構造化プロンプト、デザイン、CTO、mind-clone | ![](https://badgen.net/github/stars/langgptai/claude_marketplace) |
 
 ### モデル固有のプロンプトコレクション
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -84,7 +84,16 @@
 
 如果你使用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)，可以安装 LangGPT Skill 来获得结构化提示词编写能力：
 
-**安装方式：**
+**通过官方技能市场安装（推荐）：**
+
+```bash
+/plugin marketplace add langgptai/claude_marketplace
+/plugin install structured-prompt-writer@langgpt
+```
+
+[LangGPT 技能市场](https://github.com/langgptai/claude_marketplace) 还收录了云中江树打磨的更多实战技能 —— `awesome-design-html`（115 套品牌主题设计参考）、`cto`、`mind-clone`。
+
+**或手动安装：**
 
 1. 下载 [langgpt.skill](https://github.com/langgptai/LangGPT/releases)
 2. 解压到 `~/.claude/skills/` 目录
@@ -236,6 +245,7 @@ skills:
 | **[PromptVer](https://github.com/langgptai/PromptVer)** | 提示词的语义化版本控制 — 像 Git 一样的版本管理 | ![](https://badgen.net/github/stars/langgptai/PromptVer) |
 | **[PromptShow](https://github.com/langgptai/PromptShow)** | 创建精美的提示词图片（[试试看](https://show.langgpt.ai/)） | ![](https://badgen.net/github/stars/langgptai/PromptShow) |
 | **[Minstrel](https://github.com/langgptai/Minstrel)** | 自动生成提示词的多智能体系统 | ![](https://badgen.net/github/stars/langgptai/Minstrel) |
+| **[claude_marketplace](https://github.com/langgptai/claude_marketplace)** | 官方 Claude Code 技能市场 —— 结构化提示词、设计、CTO、心智克隆 | ![](https://badgen.net/github/stars/langgptai/claude_marketplace) |
 
 ### 特定模型的提示词集合
 


### PR DESCRIPTION
## 这个 PR 做了什么

把 README 里「方法四：Claude Code Skill」从**手动下载 langgpt.skill** 升级为接入刚建好的官方技能市场 [langgptai/claude_marketplace](https://github.com/langgptai/claude_marketplace)。

### 改动
- **方法四安装方式**：改为一键命令，并引流到市场内更多技能（`awesome-design-html` / `cto` / `mind-clone`），保留手动下载作为 fallback。
  ```bash
  /plugin marketplace add langgptai/claude_marketplace
  /plugin install structured-prompt-writer@langgpt
  ```
- **Ecosystem · 核心工具表**：新增 `claude_marketplace` 一行。
- **三语同步**：README.md / README_zh.md / README_ja.md 一并更新；日文版此前**缺少**「方法四」整节，已补齐。

仅文档改动，无代码/功能变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)