### PR TITLE
docs: 修复 Star History 图表链接失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ New to GitHub contributions? Check out this [GitHub Minimal Contribution Guide](
 
 ## 📊 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.com/#langgptai/LangGPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.dera.page/#langgptai/LangGPT&Date)
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -347,7 +347,7 @@ GitHubへの貢献は初めてですか？この[GitHub最小貢献ガイド](ht
 
 ## 📊 スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.com/#langgptai/LangGPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.dera.page/#langgptai/LangGPT&Date)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -354,7 +354,7 @@ Prompt 写方法，不如写人。Prompt 写方法，是给模型步骤和工具
 
 ## 📊 Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.com/#langgptai/LangGPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=langgptai/LangGPT&type=Date)](https://star-history.dera.page/#langgptai/LangGPT&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标接口限制已经损坏，无法正常加载。

本 PR 将 README.md、README_zh.md、README_ja.md 三语版本中的 Star History 图表链接统一切换至可用的替代服务，修复图表展示问题。